### PR TITLE
Fix named capture regexp

### DIFF
--- a/output-1/config.json
+++ b/output-1/config.json
@@ -2,7 +2,7 @@
   "version": 3,
   "routes": [
     {
-      "src": "/blog/(<?url>.*)",
+      "src": "/blog/(?<url>.*)",
       "dest": "/__prerender?url=$url"
     },
     {

--- a/output-2/config.json
+++ b/output-2/config.json
@@ -2,7 +2,7 @@
   "version": 3,
   "routes": [
     {
-      "src": "/blog/(<?url>.*)",
+      "src": "/blog/(?<url>.*)",
       "dest": "/__ssr_prerender?url=$url"
     },
     {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vercel-isr-repro",
   "version": "1.0.0",
   "scripts": {
-    "build": "cp -a output-1 .vercel/output"
+    "build": "rm -rfv .vercel/output && cp -av output-${VE-1} .vercel/output"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
The issue with the Prerender not being routed to was due to a bad regexp

Also tweaked the build command to accept an env var `VE` to specify which "output" to deploy.